### PR TITLE
Make an example command more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ arc` option isn’t necessary.
 Use `-r` to specify which runtime to use:
 
 ```
-$ amacx -r srcloc foo.arc
+$ amacx -r srcloc -u arc foo.arc
 ```
 
 `-I path` adds a directory to the search path that `use` loads features


### PR DESCRIPTION
As I made this PR I noticed the paragraph above which mentioned adding `(use arc)` to foo.arc. So maybe this PR isn't a good idea. But I thought I'd bring up that you're making an assumption about a file that's not in the repo. I tend to prefer to provide an example file readers can run.

I haven't read much farther down the readme, but are runtimes orthogonal to `use` "features"? Is the command I've changed here really using the `srcloc` runtime?